### PR TITLE
Commented XML asserts

### DIFF
--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-5.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-5.xml
@@ -79,14 +79,14 @@
        </operation> 
     </action>        
     <action>
-      <assert>
+      <!--<assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
         <headerField value="Accept"/>
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -127,13 +127,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+    <<!--action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-6.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-6.xml
@@ -78,7 +78,7 @@
          </requestHeader>
        </operation> 
     </action>        
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -86,7 +86,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -127,13 +127,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+   <!-- <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-7.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/AdministrationAgreement/medmij-medication-administrationagreement-fhir3-0-1-phr-1-7.xml
@@ -72,7 +72,7 @@
                  </requestHeader>
       </operation> 
     </action>        
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -80,7 +80,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -121,13 +121,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-5.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-5.xml
@@ -78,7 +78,7 @@
         </requestHeader>
       </operation> 
     </action>        
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -86,7 +86,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -127,13 +127,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-6.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-6.xml
@@ -78,7 +78,7 @@
         </requestHeader>
       </operation> 
     </action>        
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -86,7 +86,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -127,13 +127,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-7.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/Dispense/medmij-medication-dispense-fhir3-0-1-phr-1-7.xml
@@ -72,7 +72,7 @@
         </requestHeader>
       </operation> 
     </action>        
-    <action>
+    <<!--action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -80,7 +80,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -121,13 +121,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+    <ac<!--tion>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/DispenseRequest/medmij-medication-dispenserequest-fhir3-0-1-phr-1-4.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/DispenseRequest/medmij-medication-dispenserequest-fhir3-0-1-phr-1-4.xml
@@ -72,7 +72,7 @@
         </requestHeader>
       </operation> 
     </action>        
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -80,7 +80,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -121,13 +121,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-1.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-1.xml
@@ -194,7 +194,7 @@
           </requestHeader>
         </operation> 
       </action>       
-      <action>
+      <!--<action>
         <assert>
           <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
           <direction value="request"/>
@@ -202,7 +202,7 @@
           <operator value="contains"/>
           <value value="application/fhir+xml"/>
         </assert>
-      </action>
+      </action>-->
       <action>
         <assert>
           <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -313,7 +313,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -321,7 +321,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -362,13 +362,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-7.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-7.xml
@@ -71,7 +71,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -79,7 +79,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -120,13 +120,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />
@@ -190,7 +190,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -198,7 +198,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -239,13 +239,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />
@@ -309,7 +309,7 @@
         </requestHeader>
        </operation> 
     </action>       
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -317,7 +317,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -358,13 +358,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+   <!-- <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />
@@ -428,7 +428,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -436,7 +436,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -477,13 +477,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />
@@ -547,7 +547,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+ <!--   <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -555,7 +555,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -596,13 +596,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+<!--    <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />

--- a/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-8.xml
+++ b/FHIR3-0-1-MedMij-Testing/Medication/PHR-Client/MedicationTreatment/medmij-medication-treatment-fhir3-0-1-phr-1-8.xml
@@ -71,7 +71,7 @@
         </requestHeader>
       </operation> 
     </action>       
-    <action>
+  <!--  <action>
       <assert>
         <description value="Confirm that the client requested an Accept of the FHIR XML mime type 'application/fhir+xml'."/>
         <direction value="request"/>
@@ -79,7 +79,7 @@
         <operator value="contains"/>
         <value value="application/fhir+xml"/>
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the client did not request a Content-Type. Warning only to allow for systems that automatically send Content-Type."/>
@@ -120,13 +120,13 @@
         <responseCode value="200" />
       </assert>
     </action>
-    <action>
+   <!-- <action>
       <assert>
         <description value="Confirm that the returned HTTP Header Content-Type contains the FHIR mime-type 'application/fhir+xml'." />
         <direction value="response" />
         <contentType value="xml" />
       </assert>
-    </action>
+    </action>-->
     <action>
       <assert>
         <description value="Confirm that the returned resource type is Bundle." />


### PR DESCRIPTION
Commented asserts based on xml, so the test will also succeed when JSON is requested.
For Headers with Accept and Content-Type

These are already commented in all other files, but were missing in these files.
I was not able to succeed the touchstone tests because our FHIRClient needs a json result but were asserted with xml.

<img width="886" alt="screenshot 2019-01-25 13 08 25" src="https://user-images.githubusercontent.com/8653723/51745192-6141be00-20a2-11e9-8004-47018adb90d5.png">
