### PR TITLE
Generalize the inclusion of parts

### DIFF
--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkQRIsAlgemeneIntake.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkQRIsAlgemeneIntake.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that the values of the top level linkId items match the Questionnaire 'Algemene intake'"/>
@@ -7,4 +7,4 @@
             <expression value="entry.where(resource as QuestionnaireResponse).resource.item.where(linkId = 'algemeen').exists() and entry.where(resource as QuestionnaireResponse).resource.item.where(linkId = 'voorgeschiedenis').exists() and entry.where(resource as QuestionnaireResponse).resource.item.where(linkId = 'socialemedia').exists() and entry.where(resource as QuestionnaireResponse).resource.item.where(linkId = 'contactgegevens').exists() and entry.where(resource as QuestionnaireResponse).resource.item.where(linkId = 'belafspraak').exists()"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkTaskUpdate.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkTaskUpdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include scope="common" value="assert-authorizationHeader"/>
     <action>
         <assert>
             <description value="Confirm that the request body is a Task"/>
@@ -15,7 +15,7 @@
             <expression value="meta.profile = 'http://nictiz.nl/fhir/StructureDefinition/vl-QuestionnaireProvisioningTask'"/>
         </assert>
     </action>
-    <nts:include href="../../../general/common-tests/assert-responseSuccess.xml"/>
+    <nts:include scope="common" value="assert-responseSuccess"/>
     
     <nts:profile id="Task-profile" value="http://nictiz.nl/fhir/StructureDefinition/vl-QuestionnaireProvisioningTask"/> 
     <action>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkTaskUpdate.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-assert-checkTaskUpdate.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:actions href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
     <action>
         <assert>
             <description value="Confirm that the request body is a Task"/>
@@ -15,7 +15,7 @@
             <expression value="meta.profile = 'http://nictiz.nl/fhir/StructureDefinition/vl-QuestionnaireProvisioningTask'"/>
         </assert>
     </action>
-    <nts:actions href="../../../general/common-tests/assert-responseSuccess.xml"/>
+    <nts:include href="../../../general/common-tests/assert-responseSuccess.xml"/>
     
     <nts:profile id="Task-profile" value="http://nictiz.nl/fhir/StructureDefinition/vl-QuestionnaireProvisioningTask"/> 
     <action>
@@ -41,5 +41,5 @@
             </rule>
         </assert>
     </action>
-
-</actions>
+    
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-operation-updateTask.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-operation-updateTask.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Update a previously retrieved Task. This depends on a fixture called 'task-update-fixture' to be present. --> 
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -22,4 +22,4 @@
             <sourceId value="task-update-fixture"/>
         </operation>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario1-searchTask.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario1-searchTask.xml
@@ -21,7 +21,7 @@
             <responseId value="search-response"/>
         </operation>
     </action>
-    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include scope="common" value="assert-authorizationHeader"/>
     <action>
         <assert>
             <description value="Confirm that query parameter 'owner=' was not present to avoid BSNs in the URL."/>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario1-searchTask.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario1-searchTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -21,7 +21,7 @@
             <responseId value="search-response"/>
         </operation>
     </action>
-    <nts:actions href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
     <action>
         <assert>
             <description value="Confirm that query parameter 'owner=' was not present to avoid BSNs in the URL."/>
@@ -45,4 +45,4 @@
             <expression value="Bundle.total = 1"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario2-retrieveQuestionnaire.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario2-retrieveQuestionnaire.xml
@@ -20,7 +20,7 @@
             </requestHeader>
         </operation>
     </action>
-    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include scope="common" value="assert-authorizationHeader"/>
     <action>
         <assert>
             <description value="Confirm that a Questionnaire instance is returned"/>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario2-retrieveQuestionnaire.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario2-retrieveQuestionnaire.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -20,11 +20,11 @@
             </requestHeader>
         </operation>
     </action>
-    <nts:actions href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
     <action>
         <assert>
             <description value="Confirm that a Questionnaire instance is returned"/>
             <resource value="Questionnaire"/>
         </assert>
     </action>
-</actions>    
+</nts:parts>    

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-acceptTaskUpdate.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-acceptTaskUpdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:actions href="phr-operation-updateTask.xml"/>
-    <nts:actions href="phr-assert-checkTaskUpdate.xml"/>   
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <nts:include href="phr-operation-updateTask.xml"/>
+    <nts:include href="phr-assert-checkTaskUpdate.xml"/>   
     <action>
         <assert>
             <description value="Confirm that the status of the Task is 'accepted'"/>
@@ -9,4 +9,4 @@
             <expression value="Task.status = 'accepted'"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-acceptTaskUpdate.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-acceptTaskUpdate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:include href="phr-operation-updateTask.xml"/>
-    <nts:include href="phr-assert-checkTaskUpdate.xml"/>   
+    <nts:include value="phr-operation-updateTask"/>
+    <nts:include value="phr-assert-checkTaskUpdate"/>   
     <action>
         <assert>
             <description value="Confirm that the status of the Task is 'accepted'"/>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-handleTransaction.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-handleTransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -20,7 +20,7 @@
             <sourceId value="response-bundle-fixture"/>
         </operation>
     </action>
-    <nts:actions href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
     <action>
         <assert>
             <description value="Confirm that the client posted a Bundle"/>
@@ -137,4 +137,4 @@
             <expression value="entry.where(resource as QuestionnaireResponse).response.status.startsWith('201')"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-handleTransaction.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-scenario3-handleTransaction.xml
@@ -20,7 +20,7 @@
             <sourceId value="response-bundle-fixture"/>
         </operation>
     </action>
-    <nts:include href="../../../general/common-tests/assert-authorizationHeader.xml"/>
+    <nts:include scope="common" value="assert-authorizationHeader"/>
     <action>
         <assert>
             <description value="Confirm that the client posted a Bundle"/>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-setup-checkForOpenTasks.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-setup-checkForOpenTasks.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <!-- Search for open Tasks. If they are present, another test is
                  running at the moment and this test cannot proceed. -->
     <action>
@@ -28,5 +28,5 @@
             <expression value="Bundle.total = 0"/>
         </assert>
     </action>
-</actions>
+</nts:parts>
 

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-setup-createTask.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-setup-createTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <!-- Create Task resource with unique ID.
          Note: the "autocreate" option can't be used because it misses the authorization headers -->
     <action>
@@ -22,4 +22,4 @@
             <sourceId value="task-requested-fixture"/>
         </operation>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-teardown-deleteQuestionnaireResponse.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-teardown-deleteQuestionnaireResponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <!-- Delete the created QuestionnaireResponse. -->
@@ -20,4 +20,4 @@
             </requestHeader>
         </operation>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-teardown-deleteTask.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-teardown-deleteTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <!-- Delete the (now modified) Task resource.
@@ -21,4 +21,4 @@
             </requestHeader>
         </operation>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-happyFlow.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-happyFlow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:include href="phr-variables-taskId.xml"/>
+    <nts:include value="phr-variables-taskId"/>
     <variable>
         <name value="questionnaire-id"/>
         <expression value="Questionnaire.id"/>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-happyFlow.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-happyFlow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<variables xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:variables href="phr-variables-taskId.xml"/>
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <nts:include href="phr-variables-taskId.xml"/>
     <variable>
         <name value="questionnaire-id"/>
         <expression value="Questionnaire.id"/>
@@ -24,4 +24,4 @@
         <expression value="link.url.replace('Task?code=http%3A%2F%2Floinc.org%7C74468-0&amp;status=requested', '')"/>
         <sourceId value="search-response"/>
     </variable>
-</variables>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-taskId.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/components/phr-variables-taskId.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<variables xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <variable>
         <name value="task-id"/>
         <expression value="Task.id"/>
         <sourceId value="task-requested-fixture"/>
     </variable>
-</variables>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-1_2-1_3-1.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-1_2-1_3-1.xml
@@ -3,8 +3,7 @@
 <TestScript xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <id value="medmij-questionnaires-fhir3-0-1-phr-1.1-2.1-3.1"/>
     <name value="MedMij Questionnaires - PHR Client - Scenario 1.1, 2.1, 3.1"/>
-    <description value="MedMij Questionnaires for FHIR STU3 - PHR Client - Scenario 1.1, 2.1, 3.1 - Retrieve QuestionnaireProvisioningTask, retrieve Questionnaire, and send QuestionnaireResponse"/>
-    
+    <description value="MedMij Questionnaires for FHIR STU3 - PHR Client - Scenario 1.1, 2.1, 3.1 - Retrieve QuestionnaireProvisioningTask, retrieve Questionnaire, and send QuestionnaireResponse"/>    
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-VERKEULEN-token.xml" type="phr"/>
     <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-REQUESTED.xml"/>
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-ACCEPTED.xml"/>    
@@ -13,38 +12,38 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-INTAKE-NIEUWE-PATIENT.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-Intake.xml"/>
        
-    <nts:include href="components/phr-variables-happyFlow.xml"/>
+    <nts:include value="phr-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:include href="components/phr-setup-createTask.xml"/>
+        <nts:include value="phr-setup-checkForOpenTasks"/>
+        <nts:include value="phr-setup-createTask"/>
     </setup>
     
     <test id="Scenario1.1-SearchTask">
         <name value="Scenario1.1 - Search QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:include href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include value="phr-scenario1-searchTask"/>
     </test>
     <test id="Scenario2.1-RetrieveQuestionnaire">
         <name value="Scenario2.1 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include value="phr-scenario2-retrieveQuestionnaire"/>
     </test>
     <test id="Scenario3.1-part1-SendQuestionnaireResponse">
         <name value="Scenario3.1 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include value="phr-scenario3-acceptTaskUpdate"/>
     </test>
     <test id="Scenario3.1-part2-SendQuestionnaireResponse">
         <name value="Scenario3.1 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
-        <nts:include href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
+        <nts:include value="phr-scenario3-handleTransaction"/>
+        <nts:include value="phr-assert-checkQRIsAlgemeneIntake"/>
     </test>
     
     <teardown>
-        <nts:include href="components/phr-teardown-deleteTask.xml"/>
-        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include value="phr-teardown-deleteTask"/>
+        <nts:include value="phr-teardown-deleteQuestionnaireResponse"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-1_2-1_3-1.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-1_2-1_3-1.xml
@@ -13,38 +13,38 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-INTAKE-NIEUWE-PATIENT.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-Intake.xml"/>
        
-    <nts:variables href="components/phr-variables-happyFlow.xml"/>
+    <nts:include href="components/phr-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:actions href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:actions href="components/phr-setup-createTask.xml"/>
+        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
+        <nts:include href="components/phr-setup-createTask.xml"/>
     </setup>
     
     <test id="Scenario1.1-SearchTask">
         <name value="Scenario1.1 - Search QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:actions href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include href="components/phr-scenario1-searchTask.xml"/>
     </test>
     <test id="Scenario2.1-RetrieveQuestionnaire">
         <name value="Scenario2.1 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:actions href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
     </test>
     <test id="Scenario3.1-part1-SendQuestionnaireResponse">
         <name value="Scenario3.1 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:actions href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
     </test>
     <test id="Scenario3.1-part2-SendQuestionnaireResponse">
         <name value="Scenario3.1 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:actions href="components/phr-scenario3-handleTransaction.xml"/>
-        <nts:actions href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
+        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
+        <nts:include href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
     </test>
     
     <teardown>
-        <nts:actions href="components/phr-teardown-deleteTask.xml"/>
-        <nts:actions href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-2_2-2_3-2.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-2_2-2_3-2.xml
@@ -12,33 +12,33 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-PHQ-9.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-PHQ9.xml"/>
        
-    <nts:include href="components/phr-variables-happyFlow.xml"/>
+    <nts:include value="phr-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:include href="components/phr-setup-createTask.xml"/>
+        <nts:include value="phr-setup-checkForOpenTasks"/>
+        <nts:include value="phr-setup-createTask"/>
     </setup>
     
     <test id="Scenario1.2-SearchTask">
         <name value="Scenario1.2 - Search QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:include href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include value="phr-scenario1-searchTask"/>
     </test>
     <test id="Scenario2.2-RetrieveQuestionnaire">
         <name value="Scenario2.1 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include value="phr-scenario2-retrieveQuestionnaire"/>
     </test>
     <test id="Scenario3.2-part1-SendQuestionnaireResponse">
         <name value="Scenario3.2 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include value="phr-scenario3-acceptTaskUpdate"/>
     </test>
     <test id="Scenario3.2-part2-SendQuestionnaireResponse">
         <name value="Scenario3.2 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
+        <nts:include value="phr-scenario3-handleTransaction"/>
         
         <action>
             <assert>
@@ -57,7 +57,7 @@
     </test>
     
     <teardown>
-        <nts:include href="components/phr-teardown-deleteTask.xml"/>
-        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include value="phr-teardown-deleteTask"/>
+        <nts:include value="phr-teardown-deleteQuestionnaireResponse"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-2_2-2_3-2.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-2_2-2_3-2.xml
@@ -12,33 +12,33 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-PHQ-9.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-PHQ9.xml"/>
        
-    <nts:variables href="components/phr-variables-happyFlow.xml"/>
+    <nts:include href="components/phr-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:actions href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:actions href="components/phr-setup-createTask.xml"/>
+        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
+        <nts:include href="components/phr-setup-createTask.xml"/>
     </setup>
     
     <test id="Scenario1.2-SearchTask">
         <name value="Scenario1.2 - Search QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:actions href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include href="components/phr-scenario1-searchTask.xml"/>
     </test>
     <test id="Scenario2.2-RetrieveQuestionnaire">
         <name value="Scenario2.1 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:actions href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
     </test>
     <test id="Scenario3.2-part1-SendQuestionnaireResponse">
         <name value="Scenario3.2 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:actions href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
     </test>
     <test id="Scenario3.2-part2-SendQuestionnaireResponse">
         <name value="Scenario3.2 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:actions href="components/phr-scenario3-handleTransaction.xml"/>
+        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
         
         <action>
             <assert>
@@ -57,7 +57,7 @@
     </test>
     
     <teardown>
-        <nts:actions href="components/phr-teardown-deleteTask.xml"/>
-        <nts:actions href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-3_2-3_3-3.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-3_2-3_3-3.xml
@@ -12,38 +12,38 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-INTAKE-NIEUWE-PATIENT.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-Intake.xml"/>
     
-    <nts:variables href="components/phr-variables-happyFlow.xml"/>
+    <nts:include href="components/phr-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:actions href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:actions href="components/phr-setup-createTask.xml"/>
+        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
+        <nts:include href="components/phr-setup-createTask.xml"/>
     </setup>
     
     <test id="Scenario1.3-SearchTask">
         <name value="Scenario1.3 - Search QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:actions href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include href="components/phr-scenario1-searchTask.xml"/>
     </test>
     <test id="Scenario2.3-RetrieveQuestionnaire">
         <name value="Scenario2.3 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:actions href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
     </test>
     <test id="Scenario3.3-part1-SendQuestionnaireResponse">
         <name value="Scenario3.3 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:actions href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
     </test>
     <test id="Scenario3.3-part2-SendQuestionnaireResponse">
         <name value="Scenario3.3 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:actions href="components/phr-scenario3-handleTransaction.xml"/>
-        <nts:actions href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
+        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
+        <nts:include href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
     </test>
     
     <teardown>
-        <nts:actions href="components/phr-teardown-deleteTask.xml"/>
-        <nts:actions href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-3_2-3_3-3.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-3_2-3_3-3.xml
@@ -12,38 +12,38 @@
     <nts:fixture id="questionnaire-fixture" href="resources/resources-questionnaires/medmij-questionnaires-fhir3-0-1-vl-Questionnaire-INTAKE-NIEUWE-PATIENT.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-Intake.xml"/>
     
-    <nts:include href="components/phr-variables-happyFlow.xml"/>
+    <nts:include value="phr-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:include href="components/phr-setup-createTask.xml"/>
+        <nts:include value="phr-setup-checkForOpenTasks"/>
+        <nts:include value="phr-setup-createTask"/>
     </setup>
     
     <test id="Scenario1.3-SearchTask">
         <name value="Scenario1.3 - Search QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:include href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include value="phr-scenario1-searchTask"/>
     </test>
     <test id="Scenario2.3-RetrieveQuestionnaire">
         <name value="Scenario2.3 - Retrieve Questionnaire"/>
         <description value="Test PHR client to retrieve the Questionnaire resource specified in the QuestionnaireProvisioningTask.output:Questionnaire.reference. This should be a single GET on the Questionnaire resource."/>
-        <nts:include href="components/phr-scenario2-retrieveQuestionnaire.xml"/>
+        <nts:include value="phr-scenario2-retrieveQuestionnaire"/>
     </test>
     <test id="Scenario3.3-part1-SendQuestionnaireResponse">
         <name value="Scenario3.3 - Part 1 - Accept QuestionnaireProvisioningTask"/>
         <description value="Test PHR client to send an update of the QuestionnaireProvisioningTask with status='accepted'. The body of the request should otherwise be the same as the original Task as received from the server."/>
-        <nts:include href="components/phr-scenario3-acceptTaskUpdate.xml"/>
+        <nts:include value="phr-scenario3-acceptTaskUpdate"/>
     </test>
     <test id="Scenario3.3-part2-SendQuestionnaireResponse">
         <name value="Scenario3.3 - Part 2 - Send QuestionnaireResponse"/>
         <description value="Test PHR client to complete the QuestionnaireProvisioningTask with a QuestionnaireResponse instance. This should be a transaction where Task status is set to 'completed', the QuestionnaireResponse is created and the QuestionnaireResponse is linked in Task.output."/>
-        <nts:include href="components/phr-scenario3-handleTransaction.xml"/>
-        <nts:include href="components/phr-assert-checkQRIsAlgemeneIntake.xml"/>
+        <nts:include value="phr-scenario3-handleTransaction"/>
+        <nts:include value="phr-assert-checkQRIsAlgemeneIntake"/>
     </test>
     
     <teardown>
-        <nts:include href="components/phr-teardown-deleteTask.xml"/>
-        <nts:include href="components/phr-teardown-deleteQuestionnaireResponse.xml"/>
+        <nts:include value="phr-teardown-deleteTask"/>
+        <nts:include value="phr-teardown-deleteQuestionnaireResponse"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-4_2-4.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-4_2-4.xml
@@ -11,24 +11,24 @@
     <nts:fixture id="task-minimum-fixture-json" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-minimum.json"/>
     
     
-    <nts:include href="components/phr-variables-taskId.xml"/>
+    <nts:include value="phr-variables-taskId"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:include href="components/phr-setup-createTask.xml"/>
+        <nts:include value="phr-setup-checkForOpenTasks"/>
+        <nts:include value="phr-setup-createTask"/>
     </setup>
     
     <test id="Scenario1.4-SearchTask">
         <name value="Scenario1.4 - Search QuestionnaireProvisioningTask(s) for patient 3"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:include href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include value="phr-scenario1-searchTask"/>
     </test>
     <test id="Scenario2.4-FailTask">
         <name value="Scenario2.4 - Set QuestionnaireProvisioningTask to 'failed'"/>
         <description value="Test PHR client to set the status of the QuestionnaireProvisioningTask to 'failed' when the Questionnaire cannot be retrieved."/>
-        <nts:include href="components/phr-operation-updateTask.xml"/>
-        <nts:include href="components/phr-assert-checkTaskUpdate.xml"/>
+        <nts:include value="phr-operation-updateTask"/>
+        <nts:include value="phr-assert-checkTaskUpdate"/>
         <action>
             <assert>
                 <description value="Confirm that the status of the Task is 'failed'"/>
@@ -39,6 +39,6 @@
     </test>            
     
     <teardown>
-        <nts:include href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include value="phr-teardown-deleteTask"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-4_2-4.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-4_2-4.xml
@@ -11,24 +11,24 @@
     <nts:fixture id="task-minimum-fixture-json" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-minimum.json"/>
     
     
-    <nts:variables href="components/phr-variables-taskId.xml"/>
+    <nts:include href="components/phr-variables-taskId.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:actions href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:actions href="components/phr-setup-createTask.xml"/>
+        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
+        <nts:include href="components/phr-setup-createTask.xml"/>
     </setup>
     
     <test id="Scenario1.4-SearchTask">
         <name value="Scenario1.4 - Search QuestionnaireProvisioningTask(s) for patient 3"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:actions href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include href="components/phr-scenario1-searchTask.xml"/>
     </test>
     <test id="Scenario2.4-FailTask">
         <name value="Scenario2.4 - Set QuestionnaireProvisioningTask to 'failed'"/>
         <description value="Test PHR client to set the status of the QuestionnaireProvisioningTask to 'failed' when the Questionnaire cannot be retrieved."/>
-        <nts:actions href="components/phr-operation-updateTask.xml"/>
-        <nts:actions href="components/phr-assert-checkTaskUpdate.xml"/>
+        <nts:include href="components/phr-operation-updateTask.xml"/>
+        <nts:include href="components/phr-assert-checkTaskUpdate.xml"/>
         <action>
             <assert>
                 <description value="Confirm that the status of the Task is 'failed'"/>
@@ -39,6 +39,6 @@
     </test>            
     
     <teardown>
-        <nts:actions href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include href="components/phr-teardown-deleteTask.xml"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-5_2-5.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-5_2-5.xml
@@ -11,24 +11,24 @@
     <nts:fixture id="task-minimum-fixture-json" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-minimum.json"/>
     
     
-    <nts:include href="components/phr-variables-taskId.xml"/>
+    <nts:include value="phr-variables-taskId"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:include href="components/phr-setup-createTask.xml"/>
+        <nts:include value="phr-setup-checkForOpenTasks"/>
+        <nts:include value="phr-setup-createTask"/>
     </setup>
     
     <test id="Scenario1.5-SearchTask">
         <name value="Scenario1.5 - Search QuestionnaireProvisioningTask(s) for patient 3"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:include href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include value="phr-scenario1-searchTask"/>
     </test>
     <test id="Scenario2.5-RejectTask">
         <name value="Scenario2.5 - Set QuestionnaireProvisioningTask to 'rejected'"/>
         <description value="Test PHR client to set the status of the QuestionnaireProvisioningTask to 'rejected' when the Questionnaire cannot be rendered."/>
-        <nts:include href="components/phr-operation-updateTask.xml"/>
-        <nts:include href="components/phr-assert-checkTaskUpdate.xml"/>
+        <nts:include value="phr-operation-updateTask"/>
+        <nts:include value="phr-assert-checkTaskUpdate"/>
         <action>
             <assert>
                 <description value="Confirm that the status of the Task is 'rejected'"/>
@@ -39,6 +39,6 @@
     </test>            
     
     <teardown>
-        <nts:include href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include value="phr-teardown-deleteTask"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-5_2-5.xml
+++ b/Generate/Questionnaires-1-0-0/PHR-Client/medmij-questionnaires-fhir3-0-1-phr-1-5_2-5.xml
@@ -11,24 +11,24 @@
     <nts:fixture id="task-minimum-fixture-json" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-minimum.json"/>
     
     
-    <nts:variables href="components/phr-variables-taskId.xml"/>
+    <nts:include href="components/phr-variables-taskId.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
-        <nts:actions href="components/phr-setup-checkForOpenTasks.xml"/>
-        <nts:actions href="components/phr-setup-createTask.xml"/>
+        <nts:include href="components/phr-setup-checkForOpenTasks.xml"/>
+        <nts:include href="components/phr-setup-createTask.xml"/>
     </setup>
     
     <test id="Scenario1.5-SearchTask">
         <name value="Scenario1.5 - Search QuestionnaireProvisioningTask(s) for patient 3"/>
         <description value="Test PHR client to search for QuestionnaireProvisioningTasks with status 'requested'. The return value should be a Bundle with a single entry."/>
-        <nts:actions href="components/phr-scenario1-searchTask.xml"/>
+        <nts:include href="components/phr-scenario1-searchTask.xml"/>
     </test>
     <test id="Scenario2.5-RejectTask">
         <name value="Scenario2.5 - Set QuestionnaireProvisioningTask to 'rejected'"/>
         <description value="Test PHR client to set the status of the QuestionnaireProvisioningTask to 'rejected' when the Questionnaire cannot be rendered."/>
-        <nts:actions href="components/phr-operation-updateTask.xml"/>
-        <nts:actions href="components/phr-assert-checkTaskUpdate.xml"/>
+        <nts:include href="components/phr-operation-updateTask.xml"/>
+        <nts:include href="components/phr-assert-checkTaskUpdate.xml"/>
         <action>
             <assert>
                 <description value="Confirm that the status of the Task is 'rejected'"/>
@@ -39,6 +39,6 @@
     </test>            
     
     <teardown>
-        <nts:actions href="components/phr-teardown-deleteTask.xml"/>
+        <nts:include href="components/phr-teardown-deleteTask.xml"/>
     </teardown>
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assert-taskAccepted.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assert-taskAccepted.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions  xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that Task.status is 'accepted'"/>
@@ -7,4 +7,4 @@
             <expression value="Task.status = 'accepted'"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assert-transactionBundle.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assert-transactionBundle.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions  xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts  xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that the Bundle is of type 'transaction'"/>
@@ -7,4 +7,4 @@
             <expression value="Bundle.type = 'transaction'"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assertTransactionSucces.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-assertTransactionSucces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that the transaction was succesful"/>
@@ -35,4 +35,4 @@
             <expression value="entry.where(resource as Task).resource.output.where(type.text = 'QuestionnaireResponse').value.reference = entry.where(resource as QuestionnaireResponse).fullUrl"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario1-serveTask.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario1-serveTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -55,4 +55,4 @@
         </assert>
     </action>
     
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveQuestionnaireResponse.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveQuestionnaireResponse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -20,5 +20,5 @@
             <sourceId value="response-bundle-fixture"/>
         </operation>
     </action>
-    <nts:actions href="xis-assert-transactionBundle.xml"/>
-</actions>
+    <nts:include href="xis-assert-transactionBundle.xml"/>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveQuestionnaireResponse.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveQuestionnaireResponse.xml
@@ -20,5 +20,5 @@
             <sourceId value="response-bundle-fixture"/>
         </operation>
     </action>
-    <nts:include href="xis-assert-transactionBundle.xml"/>
+    <nts:include value="xis-assert-transactionBundle"/>
 </nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveTaskUpdate.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-scenario3-receiveTaskUpdate.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions  xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <operation>
             <type>
@@ -28,4 +28,4 @@
             <responseCode value="200,201"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-setup-createTask.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-setup-createTask.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <variable>
         <name value="task-initial-id" />
         <expression value="Task.id"/>
@@ -31,4 +31,4 @@
             <responseCode value="200,201" />
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-happyFlow.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-happyFlow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:include href="xis-variables-taskId.xml"/>
+    <nts:include value="xis-variables-taskId"/>
     <variable>
         <name value="task-fullurl"/>
         <!-- Assume there's just one entry, which is a requirement for the test -->

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-happyFlow.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-happyFlow.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<variables xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
-    <nts:variables href="xis-variables-taskId.xml"/>
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+    <nts:include href="xis-variables-taskId.xml"/>
     <variable>
         <name value="task-fullurl"/>
         <!-- Assume there's just one entry, which is a requirement for the test -->
@@ -14,4 +14,4 @@
         <expression value="link.url.replace('Task?code=http%3A%2F%2Floinc.org%7C74468-0&amp;status=requested', '')"/>
         <sourceId value="search-response"/>
     </variable>
-</variables>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-taskId.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/components/xis-variables-taskId.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<variables xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <variable>
         <name value="task-id"/>
         <expression value="entry.where(resource as Task).resource.id"/>
         <sourceId value="search-response"/>
     </variable>
-</variables>
+</nts:parts>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-1_3-1.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-1_3-1.xml
@@ -10,32 +10,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-Intake.xml"/>
     
-    <nts:include href="components/xis-variables-happyFlow.xml"/>
+    <nts:include value="xis-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.1-ServeTask">
         <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario3.1-RecieveTaskUpdate">
         <name value="Scenario3.1 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:include href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include value="xis-scenario3-receiveTaskUpdate"/>
+        <nts:include value="xis-assert-taskAccepted"/>
     </test>
     
     <test id="Scenario3.1-RecieveQuestionnaireResponse">
         <name value="Scenario3.1 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:include href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include value="xis-scenario3-receiveQuestionnaireResponse"/>
+        <nts:include value="xis-assertTransactionSucces"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-1_3-1.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-1_3-1.xml
@@ -10,32 +10,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-Intake.xml"/>
     
-    <nts:variables href="components/xis-variables-happyFlow.xml"/>
+    <nts:include href="components/xis-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-Intake-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.1-ServeTask">
         <name value="Scenario1.1 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario3.1-RecieveTaskUpdate">
         <name value="Scenario3.1 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:actions href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:actions href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include href="components/xis-assert-taskAccepted.xml"/>
     </test>
     
     <test id="Scenario3.1-RecieveQuestionnaireResponse">
         <name value="Scenario3.1 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:actions href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:actions href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
+        <nts:include href="components/xis-assertTransactionSucces.xml"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-2_3-2.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-2_3-2.xml
@@ -9,32 +9,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-PHQ9-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-PHQ9.xml"/>
     
-    <nts:include href="components/xis-variables-happyFlow.xml"/>
+    <nts:include value="xis-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-PHQ9-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.2-ServeTask">
         <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario3.2-RecieveTaskUpdate">
         <name value="Scenario3.2 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:include href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include value="xis-scenario3-receiveTaskUpdate"/>
+        <nts:include value="xis-assert-taskAccepted"/>
     </test>
     
     <test id="Scenario3.2-RecieveQuestionnaireResponse">
         <name value="Scenario3.2 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:include href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include value="xis-scenario3-receiveQuestionnaireResponse"/>
+        <nts:include value="xis-assertTransactionSucces"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-2_3-2.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-2_3-2.xml
@@ -9,32 +9,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-PHQ9-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Verkeulen-PHQ9.xml"/>
     
-    <nts:variables href="components/xis-variables-happyFlow.xml"/>
+    <nts:include href="components/xis-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Verkeulen-PHQ9-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.2-ServeTask">
         <name value="Scenario1.2 - Serve QuestionnaireProvisioningTask(s) for patient 1"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario3.2-RecieveTaskUpdate">
         <name value="Scenario3.2 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:actions href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:actions href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include href="components/xis-assert-taskAccepted.xml"/>
     </test>
     
     <test id="Scenario3.2-RecieveQuestionnaireResponse">
         <name value="Scenario3.2 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:actions href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:actions href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
+        <nts:include href="components/xis-assertTransactionSucces.xml"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-3_3-3.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-3_3-3.xml
@@ -9,32 +9,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-Intake-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-Intake.xml"/>
     
-    <nts:variables href="components/xis-variables-happyFlow.xml"/>
+    <nts:include href="components/xis-variables-happyFlow.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-Intake-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.3-ServeTask">
         <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario3.3-RecieveTaskUpdate">
         <name value="Scenario3.3 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:actions href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:actions href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include href="components/xis-assert-taskAccepted.xml"/>
     </test>
     
     <test id="Scenario3.3-RecieveQuestionnaireResponse">
         <name value="Scenario3.3 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:actions href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:actions href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
+        <nts:include href="components/xis-assertTransactionSucces.xml"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-3_3-3.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-3_3-3.xml
@@ -9,32 +9,32 @@
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-Intake-ACCEPTED.xml"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-Intake.xml"/>
     
-    <nts:include href="components/xis-variables-happyFlow.xml"/>
+    <nts:include value="xis-variables-happyFlow"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-Intake-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.3-ServeTask">
         <name value="Scenario1.3 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario3.3-RecieveTaskUpdate">
         <name value="Scenario3.3 - Handle update to QuestionnaireProvisioningTask"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask with status 'accepted'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
-        <nts:include href="components/xis-assert-taskAccepted.xml"/>
+        <nts:include value="xis-scenario3-receiveTaskUpdate"/>
+        <nts:include value="xis-assert-taskAccepted"/>
     </test>
     
     <test id="Scenario3.3-RecieveQuestionnaireResponse">
         <name value="Scenario3.3 - Recieve QuestionnaireResponse"/>
         <description value="Test XIS server to handle the completion of the QuestionnaireProvisioningTask. The client will send a transaction bundle with an update to the QuestionnaireProvisioningTask with status 'completed', a newly created QuestionnaireResponse, and a reference from Task.output to this response."/>
-        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
-        <nts:include href="components/xis-assertTransactionSucces.xml"/>
+        <nts:include value="xis-scenario3-receiveQuestionnaireResponse"/>
+        <nts:include value="xis-assertTransactionSucces"/>
     </test>
             
 </TestScript>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-4_3-4.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-4_3-4.xml
@@ -8,24 +8,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-VERKEULEN-token.xml" type="xis"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-PHQ9-noQR.xml"/>
     
-    <nts:variables href="components/xis-variables-taskId.xml"/>
+    <nts:include href="components/xis-variables-taskId.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-PHQ9-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.4-ServeTask">
         <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario3.4-MissingQuestionnaireResponse">
         <name value="Scenario3.4 - Reject QuestionnaireProvisioningTask status 'completed' without QuestionnaireResponse."/>
         <description value="Test XIS server to reject attempts from the client to send updates of the QuestionnaireProvisioningTask with status 'completed' without also referencing a QuestionnaireResponse resource. The server should respond with a 400 or 500 type status code and an OperationOutcome with details of the problem."/>
-        <nts:actions href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
+        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
         <action>
             <assert>
                 <description value="Confirm that the transaction is rejected"/>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-4_3-4.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-4_3-4.xml
@@ -8,24 +8,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-VERKEULEN-token.xml" type="xis"/>
     <nts:fixture id="response-bundle-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-Transaction-Bie-Verkeulen-PHQ9-noQR.xml"/>
     
-    <nts:include href="components/xis-variables-taskId.xml"/>
+    <nts:include value="xis-variables-taskId"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-Verkeulen-PHQ9-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.4-ServeTask">
         <name value="Scenario1.4 - Serve QuestionnaireProvisioningTask(s) for patient 2"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario3.4-MissingQuestionnaireResponse">
         <name value="Scenario3.4 - Reject QuestionnaireProvisioningTask status 'completed' without QuestionnaireResponse."/>
         <description value="Test XIS server to reject attempts from the client to send updates of the QuestionnaireProvisioningTask with status 'completed' without also referencing a QuestionnaireResponse resource. The server should respond with a 400 or 500 type status code and an OperationOutcome with details of the problem."/>
-        <nts:include href="components/xis-scenario3-receiveQuestionnaireResponse.xml"/>
+        <nts:include value="xis-scenario3-receiveQuestionnaireResponse"/>
         <action>
             <assert>
                 <description value="Confirm that the transaction is rejected"/>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-5_2-5.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-5_2-5.xml
@@ -7,24 +7,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-token.xml" type="xis"/>
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-FAILED.xml"/>
     
-    <nts:variables href="components/xis-variables-taskId.xml"/>
+    <nts:include href="components/xis-variables-taskId.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.5-ServeTask">
         <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario2.5-FailTask">
         <name value="Scenario2.4 - Handle update to the QuestionnaireProvisioningTask with status 'failed'"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask where the status is set to 'failed'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:actions href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
         <action>
             <assert>
                 <description value="Confirm that Task.status is 'failed'"/>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-5_2-5.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-5_2-5.xml
@@ -7,24 +7,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-token.xml" type="xis"/>
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-FAILED.xml"/>
     
-    <nts:include href="components/xis-variables-taskId.xml"/>
+    <nts:include value="xis-variables-taskId"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-invalid-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.5-ServeTask">
         <name value="Scenario1.5 - Serve QuestionnaireProvisioningTask for patient 3"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire reference in this Task is assumed to be invalid."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario2.5-FailTask">
         <name value="Scenario2.4 - Handle update to the QuestionnaireProvisioningTask with status 'failed'"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask where the status is set to 'failed'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include value="xis-scenario3-receiveTaskUpdate"/>
         <action>
             <assert>
                 <description value="Confirm that Task.status is 'failed'"/>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-6_2-6.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-6_2-6.xml
@@ -8,24 +8,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-token.xml" type="xis"/>
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-REJECTED.xml"/>
     
-    <nts:include href="components/xis-variables-taskId.xml"/>
+    <nts:include value="xis-variables-taskId"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-REQUESTED.xml" />
-        <nts:include href="components/xis-setup-createTask.xml"/>            
+        <nts:include value="xis-setup-createTask"/>            
     </setup>
     
     <test id="Scenario1.6-ServeTask">
         <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
-        <nts:include href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include value="xis-scenario1-serveTask"/>
     </test>
     
     <test id="Scenario2.6-RejectTask">
         <name value="Scenario2.6 - Handle update to the QuestionnaireProvisioningTask with status 'rejected'"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask where the status is set to 'rejected'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include value="xis-scenario3-receiveTaskUpdate"/>
         <action>
             <assert>
                 <description value="Confirm that Task.status is 'rejected'"/>

--- a/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-6_2-6.xml
+++ b/Generate/Questionnaires-1-0-0/XIS-Server/medmij-questionnaires-fhir3-0-1-xis-1-6_2-6.xml
@@ -8,24 +8,24 @@
     <nts:patientTokenFixture href="medmij-questionnaires-fhir3-0-1-nl-core-patient-BIE-token.xml" type="xis"/>
     <nts:fixture id="task-update-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-REJECTED.xml"/>
     
-    <nts:variables href="components/xis-variables-taskId.xml"/>
+    <nts:include href="components/xis-variables-taskId.xml"/>
     <nts:includeDateT value="yes"/>
     
     <setup>
         <nts:fixture id="task-requested-fixture" href="resources/resources-specific/medmij-questionnaires-fhir3-0-1-vl-QuestionnaireProvisioningTask-Bie-PHQ9E-REQUESTED.xml" />
-        <nts:actions href="components/xis-setup-createTask.xml"/>            
+        <nts:include href="components/xis-setup-createTask.xml"/>            
     </setup>
     
     <test id="Scenario1.6-ServeTask">
         <name value="Scenario1.6 - Serve QuestionnaireProvisioningTask for patient 3"/>
         <description value="Test XIS server to serve a QuestionnaireProvisioningTask with status 'requested'. This Task is found using a search operation and the XIS server should return a Bundle with a single entry. The Questionnaire referenced in this Task is assumed to be too complex to render for the client."/>
-        <nts:actions href="components/xis-scenario1-serveTask.xml"/>
+        <nts:include href="components/xis-scenario1-serveTask.xml"/>
     </test>
     
     <test id="Scenario2.6-RejectTask">
         <name value="Scenario2.6 - Handle update to the QuestionnaireProvisioningTask with status 'rejected'"/>
         <description value="Test XIS server to handle an update to the QuestionnaireProvisioningTask where the status is set to 'rejected'. This will be an update operation where the original Task is sent, with only the status element changed."/>
-        <nts:actions href="components/xis-scenario3-receiveTaskUpdate.xml"/>
+        <nts:include href="components/xis-scenario3-receiveTaskUpdate.xml"/>
         <action>
             <assert>
                 <description value="Confirm that Task.status is 'rejected'"/>

--- a/Generate/general/common-tests/assert-authorizationHeader.xml
+++ b/Generate/general/common-tests/assert-authorizationHeader.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that HTTP header Authorization contains the patient token {$patient-token-id}"/>
@@ -8,5 +8,5 @@
             <value value="${patient-token-id}"/>
         </assert>
     </action>
-</actions>
+</nts:parts>
 

--- a/Generate/general/common-tests/assert-responseSuccess.xml
+++ b/Generate/general/common-tests/assert-responseSuccess.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<actions xmlns="http://hl7.org/fhir">
+<nts:parts xmlns="http://hl7.org/fhir" xmlns:nts="http://nictiz.nl/xsl/testscript">
     <action>
         <assert>
             <description value="Confirm that the operation was succesful"/>
@@ -7,4 +7,4 @@
             <responseCode value="200,201"/>
         </assert>
     </action>
-</actions>
+</nts:parts>

--- a/Generate/general/xslt/generateTestScript.xsl
+++ b/Generate/general/xslt/generateTestScript.xsl
@@ -205,25 +205,25 @@
             </resource>
         </fixture>
     </xsl:template>
-    
+
     <!-- Epand a nts:variables element; read all f:variable elements in the referenced file and further process them --> 
-    <xsl:template match="nts:variables[@href]" mode="expand" xmlns="http://hl7.org/fhir">
+    <xsl:template match="nts:include[@href]" mode="expand" xmlns="http://hl7.org/fhir">
         <xsl:param name="testscriptBase"/>
-        <xsl:variable name="loadedVariables" as="node()*">
+        <xsl:variable name="parts" as="node()*">
             <xsl:choose>
                 <xsl:when test="$testscriptBase">
-                    <xsl:copy-of select="document(@href, $testscriptBase)/f:variables/(element()|comment())"/>
+                    <xsl:copy-of select="document(@href, $testscriptBase)/nts:parts/(element()|comment())"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:copy-of select="document(@href)/f:variables/(element()|comment())"/>
+                    <xsl:copy-of select="document(@href)/nts:parts/(element()|comment())"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
         <!-- Note: don't pass testscriptBase here, because recursive includes are relative to the including file,
              not to testscriptBase -->
-        <xsl:apply-templates select="$loadedVariables" mode="expand"/>
+        <xsl:apply-templates select="$parts" mode="expand"/>
     </xsl:template>
-    
+        
     <xsl:template match="nts:rule[@id and @href]" mode="expand" xmlns="http://hl7.org/fhir">
         <rule id="{@id}">
             <resource>
@@ -232,25 +232,7 @@
             <xsl:copy-of select="./*"/>
         </rule>
     </xsl:template>
-    
-    <!-- Expand a nts:actions element; read all f:actions elements in the referenced file and further process them -->
-    <xsl:template match="nts:actions[@href]" mode="expand" xmlns="http://hl7.org/fhir">
-        <xsl:param name="testscriptBase"/>
-        <xsl:variable name="loadedActions" as="node()*">
-            <xsl:choose>
-                <xsl:when test="$testscriptBase">
-                    <xsl:copy-of select="document(@href, $testscriptBase)/f:actions/(element()|comment())"/>
-                </xsl:when>
-                <xsl:otherwise>
-                    <xsl:copy-of select="document(@href)/f:actions/(element()|comment())"/>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:variable>
-        <!-- Note: don't pass testscriptBase here, because recursive includes are relative to the including file,
-             not to testscriptBase -->
-        <xsl:apply-templates select="$loadedActions" mode="expand"/>
-    </xsl:template>
-    
+        
     <!-- Default template in the expand mode -->
     <xsl:template match="@*|node()" mode="expand">
         <xsl:param name="testscriptBase"/>

--- a/Generate/general/xslt/generateTestScript.xsl
+++ b/Generate/general/xslt/generateTestScript.xsl
@@ -6,17 +6,26 @@
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
         
+    <!-- The base of the folder where fixtures can be found, relative to the TestScript. -->
     <xsl:param name="fixtureBase" select="'../_reference/'"/>
     
+    <!-- The folder where components for this project can be found, relative to the TestScript. -->
+    <xsl:param name="projectComponentFolder" select="'components/'"/>
+    
+    <!-- The folder where the general components for TestScript generation can be found, relative to the TestScript. -->
+    <xsl:param name="generalComponentFolder" select="'../../general/common-tests/'"/>
+    
     <!-- The main template, which will call the remaining templates.
-         param testscriptBase is an optional base (as unerstood by xsl:document()) to include the components from. -->
+         param testscriptBase is an optional base (as unerstood by xsl:document()) where the TestScript input resides.
+                              Inclusions will start relative to this base. -->
     <xsl:template name="generate" match="f:TestScript" xmlns="http://hl7.org/fhir">
         <xsl:param name="testscriptBase" select="current()"/>
                 
         <!-- Expand all the Nictiz inclusion elements to their FHIR representation --> 
         <xsl:variable name="expanded">
             <xsl:apply-templates mode="expand" select=".">
-                <xsl:with-param name="testscriptBase" select="$testscriptBase"/>
+                <xsl:with-param name="inclusionBase" select="$testscriptBase"/>
+                <xsl:with-param name="testscriptBase" select="$testscriptBase" tunnel="yes"/>
             </xsl:apply-templates>
         </xsl:variable>
         
@@ -206,24 +215,50 @@
         </fixture>
     </xsl:template>
 
-    <!-- Epand a nts:variables element; read all f:variable elements in the referenced file and further process them --> 
+    <!-- Expand a nts:include element that uses absolute references with href.
+         It will read all f:parts elements in the referenced file and process them further.
+         param inclusionBase is the base (as understood by document()) to include files relative to. It is not passed
+                             on in subsequent calls to this template, as nested nts:include's are always relative to
+                             the including file. --> 
     <xsl:template match="nts:include[@href]" mode="expand" xmlns="http://hl7.org/fhir">
-        <xsl:param name="testscriptBase"/>
-        <xsl:variable name="parts" as="node()*">
+        <xsl:param name="inclusionBase"/>
+        <xsl:variable name="document" as="node()*">
             <xsl:choose>
-                <xsl:when test="$testscriptBase">
-                    <xsl:copy-of select="document(@href, $testscriptBase)/nts:parts/(element()|comment())"/>
+                <xsl:when test="$inclusionBase">
+                    <xsl:copy-of select="document(@href, $inclusionBase)"/>
                 </xsl:when>
                 <xsl:otherwise>
-                    <xsl:copy-of select="document(@href)/nts:parts/(element()|comment())"/>
+                    <xsl:copy-of select="document(@href)"/>
                 </xsl:otherwise>
             </xsl:choose>
         </xsl:variable>
-        <!-- Note: don't pass testscriptBase here, because recursive includes are relative to the including file,
-             not to testscriptBase -->
-        <xsl:apply-templates select="$parts" mode="expand"/>
+        <xsl:apply-templates select="$document/nts:parts/(element()|comment())" mode="expand"/>
     </xsl:template>
+
+    <!-- Expand a nts:include element that uses relative references with value and scope.
+         It will convert value to a full file path, read all f:parts elements in the referenced file and process them
+         further.
+         param testscriptBase is the base (as understood by document()) to include files relative to. --> 
+    <xsl:template match="nts:include[@value]" mode="expand" xmlns="http://hl7.org/fhir">
+        <xsl:param name="testscriptBase" tunnel="yes"/>
         
+        <xsl:variable name="filePath">
+            <xsl:choose>
+                <xsl:when test="@scope = 'common'">
+                    <xsl:value-of select="nts:constructXMLFilePath($generalComponentFolder, @value)"/>
+                </xsl:when>
+                <xsl:when test="@scope = 'project' or not(@scope)">
+                    <xsl:value-of select="nts:constructXMLFilePath($projectComponentFolder, @value)"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:message terminate="yes" select="concat('Unknown inclusion scope ''', @scope, '''')"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:apply-templates select="document($filePath, $testscriptBase)/nts:parts/(element()|comment())" mode="expand"/>
+    </xsl:template>
+    
+    <!-- Expand a nts:rule element -->
     <xsl:template match="nts:rule[@id and @href]" mode="expand" xmlns="http://hl7.org/fhir">
         <rule id="{@id}">
             <resource>
@@ -235,10 +270,10 @@
         
     <!-- Default template in the expand mode -->
     <xsl:template match="@*|node()" mode="expand">
-        <xsl:param name="testscriptBase"/>
+        <xsl:param name="inclusionBase"/>
         <xsl:copy>
             <xsl:apply-templates select="@*|node()" mode="expand">
-                <xsl:with-param name="testscriptBase" select="$testscriptBase"/>
+                <xsl:with-param name="inclusionBase" select="$inclusionBase"/>
             </xsl:apply-templates>
         </xsl:copy>
     </xsl:template>
@@ -249,4 +284,48 @@
             <xsl:apply-templates select="@*|node()" mode="filter"/>
         </xsl:copy>
     </xsl:template>
+    
+    <!-- === Here be functions ==================================================================================== -->
+    
+    <!-- Construct a file path from the elements.
+         param base is the folder where the file resides
+         param filename is the name of the file in the folder
+         return the full path to the file, optionally appending the .xml extension to the filename if it doesn't
+                already have it. -->
+    <xsl:function name="nts:constructXMLFilePath" as="xs:string">
+        <xsl:param name="base" as="xs:string" />
+        <xsl:param name="filename" as="xs:string" />
+        
+        <xsl:variable name="fullFilename" select="nts:addXMLExtension($filename)"/>
+        <xsl:variable name="separator">
+            <xsl:choose>
+                <xsl:when test="ends-with($base, '/')">
+                    <xsl:value-of select="''"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="'/'"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="string-join(($base, $fullFilename), $separator)"/>
+    </xsl:function>
+
+    <!-- Add .xml to the filename if it doesn't have it already.
+         param filename is the filename, which may or may not include the extension in upper- or lowercase
+         return a filename that will have an xml extension -->
+    <xsl:function name="nts:addXMLExtension" as="xs:string">
+        <xsl:param name="filename" as="xs:string"/>
+        <xsl:variable name="fullFilename" as="xs:string">
+            <xsl:choose>
+                <xsl:when test="ends-with(lower-case($filename), '.xml')">
+                    <xsl:value-of select="$filename"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="concat($filename, '.xml')"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="$fullFilename"/>
+    </xsl:function>
+
 </xsl:stylesheet>


### PR DESCRIPTION
This change generalizes the inclusion mechanism of other parts:
- it replaces the tags nts:actions and nts:variables with a general nts:include tag
- it adds the possibility to refer files by name rather than by explicit path. The XSLT will expand the name to a full path. Using the scope attribute, it is possible to include common parts as easily as project specific parts.