### PR TITLE
MM-1335 Changed LOINC code at the qualification materials

### DIFF
--- a/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-query-send/medmij-selfmeasurements-fhir3-0-2-BloodGlucose-kwalificatie7.xml
+++ b/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-query-send/medmij-selfmeasurements-fhir3-0-2-BloodGlucose-kwalificatie7.xml
@@ -3,33 +3,6 @@
     <meta>
         <profile value="http://nictiz.nl/fhir/StructureDefinition/vitalsign-bloodglucose"/>
     </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: <a href="Patient/selfmeasurement-patient-kwalificatie2">Marieke XXX_Bergzoon</a>. Categorie: <span title="Laboratory test finding (finding) (49581000146104 - SNOMED CT)">Laboratory test finding (finding)</span>, Status: definitief<span style="display: block;">Uitvoerende: <a href="Patient/selfmeasurement-patient-kwalificatie2">Marieke XXX_Bergzoon</a>
-                    </span>
-                </caption>
-                <tbody>
-                    <tr>
-                        <th>Bepalingdatum/tijd</th>
-                        <td>${DATE, T, D, -24}T17:20:00+02:00</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Glucose [mol/volume] in capillair bloed d.m.v. glucometer (14743-9 - LOINC)">Glucose [mol/volume] in capillair bloed d.m.v. glucometer</span>
-                            <div> - voor het avondeten</div>
-                        </td>
-                        <td>6.6 mmol/l</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
     <extension url="http://hl7.org/fhir/StructureDefinition/observation-eventTiming">
         <extension url="code">
             <valueCodeableConcept>
@@ -52,8 +25,8 @@
     <code>
         <coding>
             <system value="http://loinc.org"/>
-            <code value="14743-9"/>
-            <display value="Glucose [mol/volume] in capillair bloed d.m.v. glucometer"/>
+            <code value="14770-2"/>
+            <display value="Glucose^na vasten [mol/volume] in capillair bloed d.m.v. glucometer"/>
         </coding>
     </code>
     <subject>

--- a/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-query-send/medmij-selfmeasurements-fhir3-0-2-query-send-scenario-2-3-bundle.xml
+++ b/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-query-send/medmij-selfmeasurements-fhir3-0-2-query-send-scenario-2-3-bundle.xml
@@ -79,32 +79,6 @@
                 <meta>
                     <profile value="http://nictiz.nl/fhir/StructureDefinition/vitalsign-bloodglucose"/>
                 </meta>
-                <text>
-                    <status value="extensions"/>
-                    <div xmlns="http://www.w3.org/1999/xhtml">
-                        <table>
-                            <caption>Observatie/bepaling. Subject: Marieke XXX_Bergzoon. Categorie: <span title="Laboratory test finding (finding) (49581000146104 - SNOMED CT)">Laboratory test finding (finding)</span>, Status: definitief<span style="display: block;">Uitvoerende: Marieke XXX_Bergzoon</span>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Bepalingdatum/tijd</th>
-                                    <td>${DATE, T, D, -24}T17:20:00+02:00</td>
-                                </tr>
-                                <tr>
-                                    <th>Code</th>
-                                    <th>Waarde</th>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <span title="Glucose [mol/volume] in capillair bloed d.m.v. glucometer (14743-9 - LOINC)">Glucose [mol/volume] in capillair bloed d.m.v. glucometer</span>
-                                        <div> - voor het avondeten</div>
-                                    </td>
-                                    <td>6.6 mmol/l</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </text>
                 <extension url="http://hl7.org/fhir/StructureDefinition/observation-eventTiming">
                     <extension url="code">
                         <valueCodeableConcept>
@@ -127,8 +101,8 @@
                 <code>
                     <coding>
                         <system value="http://loinc.org"/>
-                        <code value="14743-9"/>
-                        <display value="Glucose [mol/volume] in capillair bloed d.m.v. glucometer"/>
+                        <code value="14770-2"/>
+                        <display value="Glucose^na vasten [mol/volume] in capillair bloed d.m.v. glucometer"/>
                     </coding>
                 </code>
                 <subject>

--- a/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-serve-receive/medmij-selfmeasurements-fhir3-0-2-BloodGlucose-kwalificatie1.xml
+++ b/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-serve-receive/medmij-selfmeasurements-fhir3-0-2-BloodGlucose-kwalificatie1.xml
@@ -3,33 +3,6 @@
     <meta>
         <profile value="http://nictiz.nl/fhir/StructureDefinition/vitalsign-bloodglucose"/>
     </meta>
-    <text>
-        <status value="extensions"/>
-        <div xmlns="http://www.w3.org/1999/xhtml">
-            <table>
-                <caption>Observatie/bepaling. Subject: <a href="Patient/selfmeasurement-patient-kwalificatie1">Paul XXX_Bourgonjee</a>. Categorie: <span title="Laboratory test finding (finding) (49581000146104 - SNOMED CT)">Laboratory test finding (finding)</span>, Status: definitief<span style="display: block;">Uitvoerende: <a href="Practitioner/selfmeasurements-practitioner-kwalificatie1">Dr. A.F. Snijder</a>
-                    </span>
-                </caption>
-                <tbody>
-                    <tr>
-                        <th>Bepalingdatum/tijd</th>
-                        <td>${DATE, T, D, -25}T07:00:00+02:00</td>
-                    </tr>
-                    <tr>
-                        <th>Code</th>
-                        <th>Waarde</th>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span title="Glucose [mol/volume] in capillair bloed d.m.v. glucometer (14743-9 - LOINC)">Glucose [mol/volume] in capillair bloed d.m.v. glucometer</span>
-                            <div> - voor het ontbijt</div>
-                        </td>
-                        <td>6.5 mmol/l</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
-    </text>
     <extension url="http://hl7.org/fhir/StructureDefinition/observation-eventTiming">
         <extension url="code">
             <valueCodeableConcept>
@@ -52,8 +25,8 @@
     <code>
         <coding>
             <system value="http://loinc.org"/>
-            <code value="14743-9"/>
-            <display value="Glucose [mol/volume] in capillair bloed d.m.v. glucometer"/>
+            <code value="14770-2"/>
+            <display value="Glucose^na vasten [mol/volume] in capillair bloed d.m.v. glucometer"/>
         </coding>
     </code>
     <subject>

--- a/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-serve-receive/medmij-selfmeasurements-fhir3-0-2-serve-receive-scenario-2-3-bundle.xml
+++ b/FHIR3-0-2-MM202001-Dev/SelfMeasurements-2-0/_reference/resources-serve-receive/medmij-selfmeasurements-fhir3-0-2-serve-receive-scenario-2-3-bundle.xml
@@ -79,32 +79,6 @@
                 <meta>
                     <profile value="http://nictiz.nl/fhir/StructureDefinition/vitalsign-bloodglucose"/>
                 </meta>
-                <text>
-                    <status value="extensions"/>
-                    <div xmlns="http://www.w3.org/1999/xhtml">
-                        <table>
-                            <caption>Observatie/bepaling. Subject: Marieke XXX_Bergzoon. Categorie: <span title="Laboratory test finding (finding) (49581000146104 - SNOMED CT)">Laboratory test finding (finding)</span>, Status: definitief<span style="display: block;">Uitvoerende: Marieke XXX_Bergzoon</span>
-                            </caption>
-                            <tbody>
-                                <tr>
-                                    <th>Bepalingdatum/tijd</th>
-                                    <td>${DATE, T, D, -24}T17:20:00+02:00</td>
-                                </tr>
-                                <tr>
-                                    <th>Code</th>
-                                    <th>Waarde</th>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <span title="Glucose [mol/volume] in capillair bloed d.m.v. glucometer (14743-9 - LOINC)">Glucose [mol/volume] in capillair bloed d.m.v. glucometer</span>
-                                        <div> - voor het avondeten</div>
-                                    </td>
-                                    <td>6.6 mmol/l</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </text>
                 <extension url="http://hl7.org/fhir/StructureDefinition/observation-eventTiming">
                     <extension url="code">
                         <valueCodeableConcept>
@@ -127,8 +101,8 @@
                 <code>
                     <coding>
                         <system value="http://loinc.org"/>
-                        <code value="14743-9"/>
-                        <display value="Glucose [mol/volume] in capillair bloed d.m.v. glucometer"/>
+                        <code value="14770-2"/>
+                        <display value="Glucose^na vasten [mol/volume] in capillair bloed d.m.v. glucometer"/>
                     </coding>
                 </code>
                 <subject>


### PR DESCRIPTION
We have decided to use a new LOINC code in the qualification material. 

I've checked if all the (blood glucose) information from the addendum is presented. 

Removed the narrative because this will be regenerated before the release. 